### PR TITLE
(feat): Add HIV Content Package and related dependencies to distro.properties

### DIFF
--- a/distro/distro.properties
+++ b/distro/distro.properties
@@ -1,5 +1,7 @@
 name=Ref 3.x distro
 version=${project.version}
+spa.node.version=${spa.node.version}
+spa.npm.version=${spa.npm.version}
 war.openmrs=${openmrs.version}
 omod.initializer=${initializer.version}
 omod.fhir2=${fhir2.version}
@@ -36,3 +38,5 @@ omod.billing=${billing.version}
 content.referenceapplication=${reference-content.version}
 content.referenceapplication-demo=${reference-demo-content.version}
 content.path.drc=${path-drc-content.version}
+content.hiv=${hiv-content.version}
+spa.frontendModules.@openmrs/esm-patient-chart-app=${esm-patient-chart-app.version}

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -41,6 +41,10 @@
     <cohort.version>3.7.3</cohort.version>
     <reporting.version>1.27.0</reporting.version>
     <reportingrest.version>1.15.0</reportingrest.version>
+    <!-- spa modules required by the hiv content package -->
+    <spa.node.version>16.20.2</spa.node.version>
+    <spa.npm.version>8.19.4</spa.npm.version>
+    <esm-patient-chart-app.version>8.1.0</esm-patient-chart-app.version>
     <!-- the next three are required for reporting -->
     <calculation.version>1.3.0</calculation.version>
     <htmlwidgets.version>1.11.0</htmlwidgets.version>
@@ -55,6 +59,7 @@
     <stockmanagement.version>2.0.2</stockmanagement.version>
     <billing.version>1.2.0</billing.version>
     <!-- Content Packages -->
+    <hiv-content.version>1.0.0-SNAPSHOT</hiv-content.version>
     <reference-content.version>1.1.2-SNAPSHOT</reference-content.version>
     <reference-demo-content.version>1.2.0-SNAPSHOT</reference-demo-content.version>
     <path-drc-content.version>1.0.0-SNAPSHOT</path-drc-content.version>
@@ -239,6 +244,14 @@
       <scope>provided</scope>
       <type>zip</type>
     </dependency>
+    <dependency>
+      <groupId>org.openmrs.content</groupId>
+      <artifactId>hiv</artifactId>
+      <version>${hiv-content.version}</version>
+      <scope>provided</scope>
+      <type>zip</type>
+    </dependency>
+    
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <plugin>
           <groupId>org.openmrs.maven.plugins</groupId>
           <artifactId>openmrs-sdk-maven-plugin</artifactId>
-          <version>6.1.0-SNAPSHOT</version>
+          <version>6.2.0-SNAPSHOT</version>
 
         </plugin>
         <plugin>


### PR DESCRIPTION
This simply adds the HIV Content Package to distro and also goes ahead to define the node and npm versions that are compatible with the openmrs core amazoncorreleta17 image. 

Ref: https://openmrs.atlassian.net/browse/SDK-381