### PR TITLE
Include Docker compose in a tar.gz to simplify offline installs

### DIFF
--- a/.env
+++ b/.env
@@ -17,3 +17,5 @@ RESTIC_KEEP_YEARLY=3
 LOG_LEVEL=info
 CRON_SCHEDULE=*/5 * * * *
 BACKUP_PATH=./openmrs_backup
+
+TAG=latest

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -138,6 +138,11 @@ jobs:
         run: |
           mv /home/runner/docker-compose-air-gapper-*.tgz path-drc-emr-images-bundle.tgz
 
+      - name: Package docker-compose files
+        run: |
+          tar czf path-drc-docker-compose.tgz docker-compose.yml docker-compose-restore.yml .env*
+          ls -la path-drc-docker-compose.tgz
+
       - name: Upload airgap bundle artifact
         uses: actions/upload-artifact@v4
         with:
@@ -150,3 +155,4 @@ jobs:
         with:
             files: |
              path-drc-emr-images-bundle.tgz
+             path-drc-docker-compose.tgz


### PR DESCRIPTION
This PR adds support for publishing Docker Compose files as part of the release artifacts.