### PR TITLE
Set a fixed version of the form-engine-app

### DIFF
--- a/frontend/spa-assemble-config.json
+++ b/frontend/spa-assemble-config.json
@@ -8,7 +8,7 @@
     "@openmrs/esm-dispensing-app": "next",
     "@openmrs/esm-fast-data-entry-app": "next",
     "@openmrs/esm-form-builder-app": "next",
-    "@openmrs/esm-form-engine-app": "next",
+    "@openmrs/esm-form-engine-app": "v10.2.1-pre.8389",
     "@openmrs/esm-generic-patient-widgets-app": "next",
     "@openmrs/esm-help-menu-app": "next",
     "@openmrs/esm-home-app": "next",


### PR DESCRIPTION
This sets the form engine app to a fixed version to prevent the issue of the error message "The encounter datetime should be between the visit start and stop dates", as Samuel advised. Its supposed to be caused by [this](https://github.com/openmrs/openmrs-esm-patient-chart/pull/2620) PR. 