### PR TITLE
(chore) Disable recently searched patients in patient search

### DIFF
--- a/frontend/configuration/config.json
+++ b/frontend/configuration/config.json
@@ -90,6 +90,11 @@
   "@openmrs/esm-dispensing-app": {
     "completeOrderWithThisDispense": true
   },
+  "@openmrs/esm-patient-search-app": {
+    "search": {
+      "showRecentlySearchedPatients": false
+    }
+  },
   "@openmrs/esm-appointments-app": {
       "appointmentTypes": [
         "Scheduled"


### PR DESCRIPTION
Disables the recently searched patients section in the patient search app by setting `showRecentlySearchedPatients` to false. 